### PR TITLE
Change logic use when both a fixed number and percent OD min are given

### DIFF
--- a/autospotting.go
+++ b/autospotting.go
@@ -8,8 +8,8 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/cristim/autospotting/core"
-	"github.com/cristim/ec2-instances-info"
+	"github.com/blueharvest/autospotting/core"
+	"github.com/blueharvest/ec2-instances-info"
 	"github.com/namsral/flag"
 )
 

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -135,18 +135,23 @@ func (a *autoScalingGroup) loadConfOnDemand() bool {
 		OnDemandNumberLong:    a.loadNumberOnDemand,
 	}
 
+	foundLimit := false
 	for _, tagKey := range tagList {
 		if tagValue := a.getTagValue(tagKey); tagValue != nil {
 			if _, ok := loadDyn[tagKey]; ok {
 				if newValue, done := loadDyn[tagKey](tagValue); done {
-					a.minOnDemand = newValue
-					return done
+					if !foundLimit {
+						a.minOnDemand = newValue
+						foundLimit = done
+					} else if newValue > a.minOnDemand {
+						a.minOnDemand = newValue
+					}
 				}
 			}
 		}
 		debug.Println("Couldn't find tag", tagKey)
 	}
-	return false
+	return foundLimit
 }
 
 func (a *autoScalingGroup) loadBiddingPolicy(tagValue *string) (string, bool) {

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -313,7 +313,7 @@ func TestLoadConfOnDemand(t *testing.T) {
 			numberExpected:  1,
 			loadingExpected: true,
 		},
-		{name: "Number has priority on percentage value",
+		{name: "Number lower than percentage and both valid so take the percentage",
 			asgTags: []*autoscaling.TagDescription{
 				{
 					Key:   aws.String("Name"),
@@ -337,7 +337,34 @@ func TestLoadConfOnDemand(t *testing.T) {
 				},
 			),
 			maxSize:         aws.Int64(10),
-			numberExpected:  2,
+			numberExpected:  3,
+			loadingExpected: true,
+		},
+		{name: "Number higher than percentage and both valid so take the number",
+			asgTags: []*autoscaling.TagDescription{
+				{
+					Key:   aws.String("Name"),
+					Value: aws.String("asg-test"),
+				},
+				{
+					Key:   aws.String(OnDemandPercentageTag),
+					Value: aws.String("10"),
+				},
+				{
+					Key:   aws.String(OnDemandNumberLong),
+					Value: aws.String("3"),
+				},
+			},
+			asgInstances: makeInstancesWithCatalog(
+				map[string]*instance{
+					"id-1": {},
+					"id-2": {},
+					"id-3": {},
+					"id-4": {},
+				},
+			),
+			maxSize:         aws.Int64(10),
+			numberExpected:  3,
 			loadingExpected: true,
 		},
 		{name: "Number is invalid so percentage value is used",

--- a/core/config.go
+++ b/core/config.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/cristim/ec2-instances-info"
+	"github.com/blueharvest/ec2-instances-info"
 )
 
 // Config contains a number of flags and static data storing the EC2 instance

--- a/core/region_test.go
+++ b/core/region_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/cristim/ec2-instances-info"
+	"github.com/blueharvest/ec2-instances-info"
 )
 
 func Test_region_enabled(t *testing.T) {


### PR DESCRIPTION
Allow for absolute minimums for OD instance when using percentage based OD minimums.

# Issue Type

- Feature Pull Request

## Summary

We'd like to be able to set a limit on the number of OD instances that Autospotting will leave alone in a ASG by setting both an absolute minimum as well as a percentage of the pool.  The idea being to protect high variable ASG pools from going below some minimum number of instances when small, but still be able to use a high percentage of spot instances when the ASG is larger.

This change accomplishes that by taking the larger or the two limits, meaning a fixed minimum number and a percentage of the current pool, when considering whether or not to replace an OD instance in an ASG.

## Code contribution checklist

Test cases covering instances where the static number overrides the percentage and vice versa are included in the PR.

Documentation still needs to be updated.